### PR TITLE
Basic R CMD check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - uses: r-lib/actions/setup-r@v2
-    - uses: r-lib/actions/setup-r-dependencies@v
+    - uses: r-lib/actions/setup-r-dependencies@v2
       with:
         extra-packages: |
           any::rcmdcheck


### PR DESCRIPTION
These changes establish a basic workflow for loading the latest version of R and all dependencies, using built in GitHub caching to avoid reinstalling packages unnecessarily. This doesn't yet handle internal BL dependencies, nor Bioconductor dependencies.