### PR TITLE
Tweak build/check config

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,4 +14,5 @@ runs:
         needs: check
     - uses: r-lib/actions/check-r-package@v2
       with:
-        args: 'c("--no-manual", "--as-cran")'
+        args: 'c("--as-cran")
+        build_args: "--compact-vignettes=gs+qpdf")'


### PR DESCRIPTION
Small changes to the arguments passed to build and check:

- Removed `--no-manual`. This was a default from the example settings in r-lib, but I don't see any reason not to check the manual.
- Added vignette compression with `--compact-vignettes`. Failing to do so will often cause a warning in CRAN checks.
