### PR TITLE
Include rmarkdown package for building vignettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,30 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
-### Changed
-- Changed something but it is not part of the last release.
+
+---
+
+## [1.0.1] - 2023-03-30
+### Added
+- Added `rmarkdown` package to action dependencies for building vignettes
 
 ---
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added
-- For new features.
-- Added item 1.
-
-### Changed
-- For changes in existing functionality.
-- Changed item 1.
-
-### Deprecated
-- For soon-to-be removed features.
-
-### Removed
-- For now removed features.
-- Removed item 1.
-
-### Fixed
-- For any bug fixes.
-- Fixed item 1.
-
-### Security
-- In case of vulnerabilities.

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,7 @@ runs:
         extra-packages: |
           any::rcmdcheck
           any::devtools
+          any::rmarkdown
         needs: check
     - uses: r-lib/actions/check-r-package@v2
       with:


### PR DESCRIPTION
# Description
The `rmarkdown` is needed to build some vignettes. Instead of requiring it in the package dependencies, I think it's better to just include it in the build environment here. This should fix the following error.

```
Error: Error: processing vignette 'UserGuide.Rmd' failed with diagnostics:
there is no package called ‘rmarkdown’
```
### Closes #...  <!-- edit if this PR closes an Issue -->

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.